### PR TITLE
fix(build.yml): remove labbel check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,10 +34,5 @@ jobs:
   
       - name: Build and push simulation image
         run: |
-              ./scripts/build_sim.sh
-  
-      - name: No Relevant Label
-        if: env.should_build == 'false'
-        run: echo "No relevant label found, skipping build."
-  
+              ./scripts/build_sim.sh 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,33 +11,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if PR label matches
-        id: check
-        run: |
-          labels=$(jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH")
-          if echo "$labels" | grep -E "build"; then
-            echo "should_build=true" >> $GITHUB_ENV
-          else
-            echo "should_build=false" >> $GITHUB_ENV
-          fi
-
       - name: Checkout code
-        if: env.should_build == 'true'
         uses: actions/checkout@v4
         with:
           submodules: recursive
           token: ${{ secrets.WORKSPACE_ACCESS_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        if: env.should_build == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.WORKSPACE_ACCESS_TOKEN }}
 
-      - name: Cache Docker layers
-        if: env.should_build == 'true'
+      - name: Cache Docker layers 
         uses: actions/cache@v4.2.3
         with:
             path: /tmp/.docker-cache
@@ -46,7 +33,6 @@ jobs:
               docker-cache-${{ runner.os }}-
   
       - name: Build and push simulation image
-        if: env.should_build == 'true'
         run: |
               ./scripts/build_sim.sh
   


### PR DESCRIPTION
This pull request simplifies the build process by removing the conditional checks for the "build" label in the `.github/workflows/build.yml` file. The most important changes are:

Simplification of build process:

* Removed the step that checks if the PR label matches "build" and sets the `should_build` environment variable accordingly. (`.github/workflows/build.yml`, [.github/workflows/build.ymlL14-L40](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L14-L40))
* Removed the conditional `if: env.should_build == 'true'` from the steps for checking out code, logging into GitHub Container Registry, caching Docker layers, and building and pushing the simulation image. (`.github/workflows/build.yml`, [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L14-L40) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L49)