### PR TITLE
ci(sitl): push bag to s3

### DIFF
--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -57,7 +57,7 @@ jobs:
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
             unzip awscliv2.zip
             sudo ./aws/install
-            aws --version
+            aws s3 cp ~/bags s3://px4-sitl-on-aws-bags/ --recursive
 
   stop-runner:
     name: Stop self-hosted EC2 runner


### PR DESCRIPTION
This pull request includes a few changes primarily focused on updating the AWS CLI commands in the workflow file and updating the subproject commit reference.

### Changes to AWS CLI commands:

* [`.github/workflows/sitl.yml`](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602L60-R60): Replaced the `aws --version` command with an `aws s3 cp` command to copy files from the local `~/bags` directory to an S3 bucket (`s3://px4-sitl-on-aws-bags/`).

### Subproject commit update:

* [`PX4-Autopilot`](diffhunk://#diff-97b79284436004809030b92bc9c0ade7d9f4019a583c63f7af96f68aa7bf843bL1-R1): Updated the subproject commit reference to a new commit hash.