### PR TITLE
ci(build): pushing to ecr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets. REPO_TOKEN }}
+          token: ${{ secrets.REPO_TOKEN }}
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets. REPO_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
 
       - name: Cache Docker layers 
         uses: actions/cache@v4.2.3
@@ -31,8 +35,7 @@ jobs:
             key: docker-cache-${{ runner.os }}-${{ github.ref_name }}
             restore-keys: |
               docker-cache-${{ runner.os }}-
-  
+
       - name: Build and push simulation image
         run: |
-              ./scripts/build_sim.sh 
-
+          ./scripts/build_sim.sh ${{ steps.login-ecr.outputs.registry }}

--- a/scripts/build_sim.sh
+++ b/scripts/build_sim.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
+set -e
 
-# Get current timestamp
+registry=$1
 timestamp=$(date +"%Y%m%d%H%M")
+image="$registry/simulation:$timestamp"
 
-# Define image name
-image="ghcr.io/iftahnaf/simulation:$timestamp"
-
-# Build image with timestamp
 docker build -t "$image" -f ./dockers/Dockerfile.simulation .
-
-# Push both timestamped and latest tags
 docker push "$image"
-docker tag "$image" ghcr.io/iftahnaf/simulation:latest
-docker push ghcr.io/iftahnaf/simulation:latest
+
+docker tag "$image" "$registry/simulation:latest"
+docker push "$registry/simulation:latest"


### PR DESCRIPTION
This pull request includes changes to the build process in the GitHub Actions workflow and the `build_sim.sh` script to transition from GitHub Container Registry to Amazon ECR for Docker image management. The most important changes include configuring AWS credentials, updating the build script to use the new registry, and modifying the Docker login process.

Changes to GitHub Actions workflow:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L20-R29): Replaced the GitHub Container Registry login step with AWS credentials configuration and Amazon ECR login.
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L37-R41): Updated the build and push simulation image step to use the Amazon ECR registry output.

Changes to build script:

* [`scripts/build_sim.sh`](diffhunk://#diff-c46a371b704d5c4392fba351f516e950824a6fc208eafb6fabfcaa8275e17ca3R2-R12): Modified the script to accept the registry as a parameter, updated the image name to use Amazon ECR, and adjusted the tagging and pushing steps accordingly.