### PR TITLE
fix(build): correct repo name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Build and push simulation image
         run: |
-          ./scripts/build_sim.sh ${{ steps.login-ecr.outputs.registry }}
+          ./scripts/build_sim.sh

--- a/scripts/build_sim.sh
+++ b/scripts/build_sim.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 set -e
 
-registry=$1
+registry="718459739973.dkr.ecr.eu-west-1.amazonaws.com"
+repo="px4_sitl_on_aws"
 timestamp=$(date +"%Y%m%d%H%M")
-image="$registry/simulation:$timestamp"
+
+image="$registry/$repo:$timestamp"
+
+echo "🔧 Building image: $image"
 
 docker build -t "$image" -f ./dockers/Dockerfile.simulation .
+
+echo "📦 Pushing image: $image"
 docker push "$image"
 
-docker tag "$image" "$registry/simulation:latest"
-docker push "$registry/simulation:latest"
+echo "🔁 Tagging and pushing 'latest'"
+docker tag "$image" "$registry/$repo:latest"
+docker push "$registry/$repo:latest"


### PR DESCRIPTION
This pull request includes changes to the build and push process for the simulation image, specifically updating the `scripts/build_sim.sh` script and the corresponding workflow file. The most important changes include hardcoding the registry URL and repository name, and updating the workflow to match the new script parameters.

### Updates to build and push process:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L41-R41): Removed the registry parameter from the `build_sim.sh` script invocation.
* [`scripts/build_sim.sh`](diffhunk://#diff-c46a371b704d5c4392fba351f516e950824a6fc208eafb6fabfcaa8275e17ca3L4-R19): Hardcoded the registry URL and repository name, added echo statements for better logging, and updated the image tagging and pushing process.