### PR TITLE
fix: dependabot intervals, update docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
   open-pull-requests-limit: 5
   assignees:
     - iftahnaf
@@ -16,7 +16,7 @@ updates:
 - package-ecosystem: "gitsubmodule"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
   open-pull-requests-limit: 5
   assignees:
     - iftahnaf
@@ -29,7 +29,7 @@ updates:
 - package-ecosystem: "docker"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
   open-pull-requests-limit: 5
   assignees:
     - iftahnaf

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Jazzy](https://github.com/iftahnaf/px4_sitl_on_aws/actions/workflows/jazzy.yml/badge.svg)
+![Rolling](https://github.com/iftahnaf/px4_sitl_on_aws/actions/workflows/rolling.yml/badge.svg)
 # PX4 SITL on AWS — Automated Simulation & Testing Pipeline
 
 This repository demonstrates an automated workflow for running PX4 SITL (Software-In-The-Loop) simulations on AWS infrastructure — fully managed by GitHub Actions.
@@ -9,7 +11,7 @@ Once the simulation ends, a simple analysis script runs to count the number of m
 
 ```mermaid
 flowchart TB
-    A[Code Change in ROS 2 Node] --> B[GitHub Actions Triggered]
+    A[Code Change in the ROS 2 Workspace] --> B[GitHub Actions Triggered]
     B --> C[Build New Docker Image]
     C --> D[Push Image to AWS ECR]
     D --> E[Launch EC2 Instance]


### PR DESCRIPTION
This pull request includes changes to the `dependabot.yml` configuration file to adjust the update schedule and updates to the `README.md` file to include new badges and modify a flowchart.

Changes to `dependabot.yml`:

* Updated the schedule interval for `github-actions`, `gitsubmodule`, and `docker` package ecosystems from daily to weekly. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R6) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L19-R19) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L32-R32)

Updates to `README.md`:

* Added badges for Jazzy and Rolling workflows.
* Modified the flowchart to update the description of the code change step.