### PR TITLE
fix: standalone SITL setup

### DIFF
--- a/dockers/Dockerfile.simulation
+++ b/dockers/Dockerfile.simulation
@@ -1,5 +1,5 @@
 ################# Build Image #################
-FROM ghcr.io/iftahnaf/dev:latest
+FROM ghcr.io/iftahnaf/dev:latest as build
 
 ENV WORKSPACE_DIR=/workspaces/px4_sitl_on_aws
 
@@ -7,6 +7,8 @@ ENV WORKSPACE_DIR=/workspaces/px4_sitl_on_aws
 RUN git clone https://github.com/PX4/PX4-Autopilot.git ${WORKSPACE_DIR}/PX4-Autopilot
 RUN cd ${WORKSPACE_DIR}/PX4-Autopilot && . /venv/bin/activate && git submodule update --init --recursive
 RUN cd ${WORKSPACE_DIR}/PX4-Autopilot && . /venv/bin/activate && bash ./Tools/setup/ubuntu.sh
+COPY ./scripts/update_nav_dll_act.py ./update_nav_dll_act.py
+RUN python3 ./update_nav_dll_act.py
 RUN cd ${WORKSPACE_DIR}/PX4-Autopilot && \
     rm -rf ./build &&  . /venv/bin/activate && \
     make px4_sitl
@@ -16,6 +18,22 @@ COPY --chown=ros:ros ./src ${WORKSPACE_DIR}/src
 RUN cd ${WORKSPACE_DIR} && \
     export MAKEFLAGS="-j 16" && \
     colcon build --parallel-workers=2 --executor sequential --packages-ignore px4  --cmake-args "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+
+################# PRODUCTION IMAGE #################
+FROM ghcr.io/iftahnaf/dev:latest
+ENV WORKSPACE_DIR=/workspaces/px4_sitl_on_aws
+# Copy PX4-AutoPilot and install dependencies
+COPY --chown=ros:ros --from=build ${WORKSPACE_DIR}/PX4-Autopilot/build ${WORKSPACE_DIR}/PX4-Autopilot/build
+COPY --chown=ros:ros --from=build ${WORKSPACE_DIR}/PX4-Autopilot/Tools/gz ${WORKSPACE_DIR}/PX4-Autopilot/Tools/gz
+COPY --chown=ros:ros --from=build ${WORKSPACE_DIR}/PX4-Autopilot/Tools/setup/ubuntu.sh ${WORKSPACE_DIR}/PX4-Autopilot/Tools/setup/ubuntu.sh
+
+# run ubuntu.sh to install dependencies
+RUN cd ${WORKSPACE_DIR}/PX4-Autopilot && \
+    . /venv/bin/activate && \
+    bash ./Tools/setup/ubuntu.sh
+
+# Copy ROS2 packages and build
+COPY --chown=ros:ros --from=build ${WORKSPACE_DIR}/install ${WORKSPACE_DIR}/install
 
 # Copy entrypoint
 COPY --chown=ros:ros ./scripts/simulation.sh simulation.sh

--- a/scripts/update_nav_dll_act.py
+++ b/scripts/update_nav_dll_act.py
@@ -1,0 +1,37 @@
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    datefmt='%Y%m%d_%H%M%S'
+)
+
+
+def update_nav_dll_act(filepath: str, new_value: int = 0):
+    """
+    Update the NAV_DLL_ACT parameter value in a PX4 shell configuration script.
+
+    Args:
+        filepath (str): Path to the shell script file.
+        new_value (int): The new value to set (default: 0).
+    """
+    with open(filepath, 'r') as f:
+        lines = f.readlines()
+
+    updated_lines = []
+    for line in lines:
+        if line.strip().startswith("param set-default NAV_DLL_ACT"):
+            updated_line = f"param set-default NAV_DLL_ACT {new_value}\n"
+            updated_lines.append(updated_line)
+        else:
+            updated_lines.append(line)
+
+    with open(filepath, 'w') as f:
+        f.writelines(updated_lines)
+
+    logging.info(f"Updated NAV_DLL_ACT to {new_value} in {filepath}")
+
+if __name__ == "__main__":
+    filepath = "/workspaces/px4_sitl_on_aws/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500"
+    new_value = 0
+    update_nav_dll_act(filepath, new_value)

--- a/src/px4_ci_aws/launch/ci.launch.py
+++ b/src/px4_ci_aws/launch/ci.launch.py
@@ -30,30 +30,6 @@ logging.basicConfig(
     datefmt='%Y%m%d_%H%M%S'
 )
 
-def update_nav_dll_act(filepath: str, new_value: int = 0):
-    """
-    Update the NAV_DLL_ACT parameter value in a PX4 shell configuration script.
-
-    Args:
-        filepath (str): Path to the shell script file.
-        new_value (int): The new value to set (default: 0).
-    """
-    with open(filepath, 'r') as f:
-        lines = f.readlines()
-
-    updated_lines = []
-    for line in lines:
-        if line.strip().startswith("param set-default NAV_DLL_ACT"):
-            updated_line = f"param set-default NAV_DLL_ACT {new_value}\n"
-            updated_lines.append(updated_line)
-        else:
-            updated_lines.append(line)
-
-    with open(filepath, 'w') as f:
-        f.writelines(updated_lines)
-
-    logging.info(f"Updated NAV_DLL_ACT to {new_value} in {filepath}")
-
 def post_process(context: LaunchContext, arg1: LaunchConfiguration, bag_name: str, recorder: ExecuteProcess):
         time.sleep(1.0)
         pid = recorder.process_details['pid']
@@ -79,8 +55,6 @@ def post_process(context: LaunchContext, arg1: LaunchConfiguration, bag_name: st
                 logging.error(f"{topic}: no messages")
 
         logging.info(f"Bag {bag_name} has been analyzed")
-
-update_nav_dll_act("/workspaces/px4_sitl_on_aws/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/airframes/4001_gz_x500", 0)
 
 def generate_launch_description():
 

--- a/src/px4_ci_aws/launch/ci.launch.py
+++ b/src/px4_ci_aws/launch/ci.launch.py
@@ -87,7 +87,7 @@ def generate_launch_description():
     px4_launch_command = (
         "cd /workspaces/px4_sitl_on_aws/PX4-Autopilot && sleep 2 &&"
         + " HEADLESS=1 PX4_SYS_AUTOSTART=4001"
-        + " PX4_SIM_MODEL=gz_x500 make px4_sitl gz_x500"
+        + " PX4_SIM_MODEL=gz_x500 ./build/px4_sitl_default/bin/px4"
     )
 
     px4_proc = ExecuteProcess(
@@ -99,6 +99,18 @@ def generate_launch_description():
         output="screen",
         emulate_tty=True,
         name="px4",
+    )
+
+    gz_sim_command = [
+        "python3",
+        "/workspaces/px4_workspace/PX4-Autopilot/Tools/simulation/gz/simulation-gazebo",
+    ]
+
+    gz_sim = ExecuteProcess(
+        cmd=gz_sim_command,
+        name="gz_sim",
+        output="screen",
+        emulate_tty=True,
     )
 
     node_dds_agent = ExecuteProcess(
@@ -164,6 +176,7 @@ def generate_launch_description():
     
     elements_to_launch = [
         px4_proc,
+        gz_sim,
         node_arm_and_offboard,
         node_offboard,
         node_dds_agent,


### PR DESCRIPTION
This pull request includes several changes to the Dockerfile and Python scripts to improve the build process and streamline the codebase. The most important changes include the introduction of a multi-stage Docker build, the addition of a new Python script for updating parameters, and the removal of redundant code.

### Dockerfile improvements:

* [`dockers/Dockerfile.simulation`](diffhunk://#diff-0e31726a89d4b50231d8f7a3df358732cae11dd199a0c88d5a5bc9d8a3e2f058L2-R11): Introduced a multi-stage build process to separate the build and production stages. This change optimizes the final image size and ensures that only necessary files are included in the production image. [[1]](diffhunk://#diff-0e31726a89d4b50231d8f7a3df358732cae11dd199a0c88d5a5bc9d8a3e2f058L2-R11) [[2]](diffhunk://#diff-0e31726a89d4b50231d8f7a3df358732cae11dd199a0c88d5a5bc9d8a3e2f058R22-R37)

### Python script addition:

* [`scripts/update_nav_dll_act.py`](diffhunk://#diff-52e2d6092a44795b84a857cd64417949057a638feae09321f5a13d7e8674aefaR1-R37): Added a new Python script to update the `NAV_DLL_ACT` parameter in a PX4 shell configuration script. This script includes logging for better traceability.

### Codebase simplification:

* [`src/px4_ci_aws/launch/ci.launch.py`](diffhunk://#diff-7f4147c417d9dd7b5bb5d4663c4ef0198a8532921a3dc079e153d8d2dddaeb6cL33-L56): Removed the `update_nav_dll_act` function and its invocation, as this functionality has been moved to the new standalone script. [[1]](diffhunk://#diff-7f4147c417d9dd7b5bb5d4663c4ef0198a8532921a3dc079e153d8d2dddaeb6cL33-L56) [[2]](diffhunk://#diff-7f4147c417d9dd7b5bb5d4663c4ef0198a8532921a3dc079e153d8d2dddaeb6cL83-R64)
* [`src/px4_ci_aws/launch/ci.launch.py`](diffhunk://#diff-7f4147c417d9dd7b5bb5d4663c4ef0198a8532921a3dc079e153d8d2dddaeb6cR78-R89): Added a new `ExecuteProcess` for running the Gazebo simulation, which enhances the launch description with better process management. [[1]](diffhunk://#diff-7f4147c417d9dd7b5bb5d4663c4ef0198a8532921a3dc079e153d8d2dddaeb6cR78-R89) [[2]](diffhunk://#diff-7f4147c417d9dd7b5bb5d4663c4ef0198a8532921a3dc079e153d8d2dddaeb6cR153)