### PR TITLE
fix(simulation.dockerfile): fix minor issues

### DIFF
--- a/dockers/Dockerfile.simulation
+++ b/dockers/Dockerfile.simulation
@@ -15,7 +15,7 @@ RUN cd ${WORKSPACE_DIR}/PX4-Autopilot && \
 
 # Copy ROS2 packages and build
 RUN mkdir -p /msgs_ws/src
-COPY --chown=ros:ros ./src/px4_msgs ${WORKSPACE_DIR}/msgs_ws/src
+COPY --chown=ros:ros ./src/px4_msgs /msgs_ws/src
 RUN cd /msgs_ws && \
     export MAKEFLAGS="-j 16" && \
     colcon build
@@ -42,7 +42,7 @@ RUN cd ${WORKSPACE_DIR}/PX4-Autopilot && \
 
 # Copy ROS2 packages and build
 COPY --chown=ros:ros --from=build ${WORKSPACE_DIR}/install ${WORKSPACE_DIR}/install
-COPY --chown=ros:ros --from=build ${WORKSPACE_DIR}/msgs_ws/install ${WORKSPACE_DIR}/install
+COPY --chown=ros:ros --from=build /msgs_ws/install ${WORKSPACE_DIR}/install
 
 # Copy entrypoint
 COPY --chown=ros:ros ./scripts/simulation.sh simulation.sh


### PR DESCRIPTION
This pull request includes changes to the `dockers/Dockerfile.simulation` file to correct paths used in the `COPY` commands for ROS2 package installations. These changes ensure that the correct directories are targeted during the build process.

Key changes:

* [`dockers/Dockerfile.simulation`](diffhunk://#diff-0e31726a89d4b50231d8f7a3df358732cae11dd199a0c88d5a5bc9d8a3e2f058L18-R18): Corrected the path in the `COPY` command for `px4_msgs` to use an absolute path instead of a relative path.
* [`dockers/Dockerfile.simulation`](diffhunk://#diff-0e31726a89d4b50231d8f7a3df358732cae11dd199a0c88d5a5bc9d8a3e2f058L45-R45): Corrected the path in the `COPY` command for `msgs_ws/install` to use an absolute path instead of a relative path.