### PR TITLE
fix(build): msgs_ws correct path

### DIFF
--- a/dockers/Dockerfile.simulation
+++ b/dockers/Dockerfile.simulation
@@ -15,17 +15,17 @@ RUN cd ${WORKSPACE_DIR}/PX4-Autopilot && \
 
 # Copy ROS2 packages and build
 RUN mkdir -p /msgs_ws/src
-COPY --chown=ros:ros ./src/px4_msgs /msgs_ws/src
+COPY --chown=ros:ros ./src/px4_msgs /msgs_ws/src/px4_msgs
 RUN cd /msgs_ws && \
-    export MAKEFLAGS="-j 16" && \
+    export MAKEFLAGS="-j16" && \
     colcon build
 
 COPY --chown=ros:ros ./src/px4-offboard ${WORKSPACE_DIR}/src/px4-offboard
 COPY --chown=ros:ros ./src/px4_ci_aws ${WORKSPACE_DIR}/src/px4_ci_aws
 
 RUN cd ${WORKSPACE_DIR} && \
-    export MAKEFLAGS="-j 16" && \
-    bash -c "source /msgs_ws/install/local_setup.bash" && \
+    export MAKEFLAGS="-j16" && \
+    . /msgs_ws/install/local_setup.sh && \
     colcon build --parallel-workers=2 --executor sequential --packages-ignore px4  --cmake-args "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 
 ################# PRODUCTION IMAGE #################


### PR DESCRIPTION
This pull request includes changes to the `dockers/Dockerfile.simulation` file to correct file paths and improve the build process. The most important changes are:

File path corrections:
* [`dockers/Dockerfile.simulation`](diffhunk://#diff-0e31726a89d4b50231d8f7a3df358732cae11dd199a0c88d5a5bc9d8a3e2f058L18-R18): Updated the `COPY` command to copy `px4_msgs` to the correct directory.

Build process improvements:
* [`dockers/Dockerfile.simulation`](diffhunk://#diff-0e31726a89d4b50231d8f7a3df358732cae11dd199a0c88d5a5bc9d8a3e2f058L28-R28): Changed the command to source the ROS2 workspace setup script from `local_setup.bash` to `local_setup.sh`.