### PR TITLE
fix(ci.launch.py): running headless

### DIFF
--- a/src/px4_ci_aws/launch/ci.launch.py
+++ b/src/px4_ci_aws/launch/ci.launch.py
@@ -78,6 +78,7 @@ def generate_launch_description():
     gz_sim_command = [
         "python3",
         "/workspaces/px4_sitl_on_aws/PX4-Autopilot/Tools/simulation/gz/simulation-gazebo",
+        "--headless"
     ]
 
     gz_sim = ExecuteProcess(


### PR DESCRIPTION
This pull request includes a small change to the `src/px4_ci_aws/launch/ci.launch.py` file. The change adds the `--headless` option to the `gz_sim_command` list in the `generate_launch_description` function.