### PR TITLE
fix(ci): better triggering conditions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,8 @@
 name: Build
 
 on:
-  pull_request:
-    types: [closed]
-    branches:
-      - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:
@@ -22,9 +19,6 @@ jobs:
 
       - name: Cleanup Docker
         run: docker system prune -af || true
-      
-      - name: Cleanup Docker buildx cache
-        run: rm -rf /tmp/.buildx-cache || true
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -1,8 +1,16 @@
 name: Software in the Loop
 on:
   workflow_dispatch:
+    inputs:
+      sim_type:
+        description: "Simulation type"
+        required: true
+        default: "x500"
 
 jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
   start-runner:
     name: Start self-hosted EC2 runner
     runs-on: ubuntu-latest
@@ -49,6 +57,7 @@ jobs:
           mkdir bags
           docker pull 718459739973.dkr.ecr.eu-west-1.amazonaws.com/px4_sitl_on_aws:latest
           docker run --net=host --ipc=host --privileged -v ~/bags:/bags/ 718459739973.dkr.ecr.eu-west-1.amazonaws.com/px4_sitl_on_aws:latest
+          echo "Simulation type is ${{ inputs.sim_type }}"
           
       - name: Install AWS CLI and upload the bags
         run: |


### PR DESCRIPTION
This pull request introduces updates to the GitHub Actions workflows to improve reusability and add configurability. The key changes include modifying the `build.yml` workflow to support being called by other workflows, adding input parameters to the `sitl.yml` workflow, and reusing the `build.yml` workflow within `sitl.yml`.

### Workflow reusability and configuration:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L4-R5): Updated the `on` trigger to replace `pull_request` with `workflow_call`, enabling this workflow to be reused by other workflows. Removed the cleanup step for Docker buildx cache as part of streamlining. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L4-R5) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L26-L28)

* [`.github/workflows/sitl.yml`](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R4-R13): Added an `inputs` section to define a `sim_type` parameter for configurability, with a default value of `"x500"`. Reused the `build.yml` workflow by including it as a `build` job.

### Additional improvements:

* [`.github/workflows/sitl.yml`](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R60): Added a step to log the `sim_type` input value during the simulation process for better traceability.