### PR TITLE
fix(sitl.workflow): build before initialize instance

### DIFF
--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -9,10 +9,12 @@ on:
 
 jobs:
   build:
+    name: Build Docker image
     uses: ./.github/workflows/build.yml
 
   start-runner:
     name: Start self-hosted EC2 runner
+    needs: build
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/sitl.yml` file to improve the workflow configuration for building and starting a self-hosted EC2 runner. The most important changes are as follows:

### Workflow Configuration Updates:

* Added a `name` field to the `build` job for better readability and identification. (`[.github/workflows/sitl.ymlR12-R17](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R12-R17)`)
* Introduced a dependency for the `start-runner` job by adding `needs: build`, ensuring that the `build` job completes before the `start-runner` job begins. (`[.github/workflows/sitl.ymlR12-R17](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R12-R17)`)