### PR TITLE
fix(build): passing secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,15 @@ name: Build
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      REPO_TOKEN:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_REGION:
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -11,6 +11,11 @@ jobs:
   build:
     name: Build Docker image
     uses: ./.github/workflows/build.yml
+    secrets:
+      REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
 
   start-runner:
     name: Start self-hosted EC2 runner


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to include the use of secrets for improved security and configuration flexibility. The changes primarily focus on adding required secrets to the `Build` workflow and passing these secrets to dependent workflows.

### Updates to GitHub Actions workflows:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R6-R14): Added required secrets (`REPO_TOKEN`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) to the `workflow_call` event configuration. These secrets are now mandatory for workflows that call this workflow.

* [`.github/workflows/sitl.yml`](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R14-R18): Updated the `build` job to pass the required secrets (`REPO_TOKEN`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) to the `Build` workflow it uses.