### PR TITLE
fix(sitl): correct args to run

### DIFF
--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -88,11 +88,10 @@ jobs:
           echo "Duration: ${{ inputs.duration }}"
           echo "Running simulation..."
           docker pull 718459739973.dkr.ecr.eu-west-1.amazonaws.com/px4_sitl_on_aws:latest
-          docker run --net=host --ipc=host --privileged -v ~/bags:/bags/ 718459739973.dkr.ecr.eu-west-1.amazonaws.com/px4_sitl_on_aws:latest ./simulation.sh \
-            ${{ inputs.radius }} \
-            ${{ inputs.altitude }} \
-            ${{ inputs.angular_velocity }} \
-            ${{ inputs.duration }}
+          docker run --net=host --ipc=host --privileged \
+                -v ~/bags:/bags/ \
+                718459739973.dkr.ecr.eu-west-1.amazonaws.com/px4_sitl_on_aws:latest \
+                bash -c "./simulation.sh '${{ inputs.radius }}' '${{ inputs.altitude }}' '${{ inputs.angular_velocity }}' '${{ inputs.duration }}'"
 
       - name: Report
         run: cat /bags/topic_report.txt


### PR DESCRIPTION
This pull request includes a minor update to the `sitl.yml` workflow file to improve the handling of input parameters when running the Docker simulation command.

### Workflow improvement:
* Updated the `docker run` command in `.github/workflows/sitl.yml` to wrap input parameters in single quotes and execute the `simulation.sh` script using `bash -c`. This change ensures proper handling of special characters or spaces in the input parameters.