### PR TITLE
fix(build): using cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache-${{ github.run_id }}
-          key: docker-cache-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}
+          key: docker-cache-${{ runner.os }}-${{ github.ref_name }}
           restore-keys: |
             docker-cache-${{ runner.os }}-
 

--- a/scripts/build_sim.sh
+++ b/scripts/build_sim.sh
@@ -9,7 +9,7 @@ image="$registry/$repo:$timestamp"
 
 echo "Building image: $image"
 
-docker buildx create --use
+docker buildx create --use --name builder || docker buildx use builder
 
 docker buildx build \
   --cache-from=type=local,src=/tmp/.buildx-cache \


### PR DESCRIPTION
This pull request makes improvements to the Docker build process by optimizing cache usage and enhancing the buildx configuration. The changes aim to streamline workflows and improve build efficiency.

**Workflow optimization:**

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L55-R55): Removed the `github.run_id` from the `key` used for the Docker cache to allow for better cache reuse across runs.

**Buildx configuration:**

* [`scripts/build_sim.sh`](diffhunk://#diff-c46a371b704d5c4392fba351f516e950824a6fc208eafb6fabfcaa8275e17ca3L12-R12): Updated the buildx setup to include a named builder (`--name builder`) and fallback to using the existing builder if it already exists. This ensures a more consistent build environment.