### PR TITLE
fix(launch): gz sim command typo

### DIFF
--- a/src/px4_ci_aws/launch/ci.launch.py
+++ b/src/px4_ci_aws/launch/ci.launch.py
@@ -90,8 +90,8 @@ def generate_launch_description():
     gz_sim_command = [
         "python3",
         "/workspaces/px4_sitl_on_aws/PX4-Autopilot/Tools/simulation/gz/simulation-gazebo",
-        " --headless"
-        " --overwrite",
+        "--headless",
+        "--overwrite",
     ]
 
     gz_sim = ExecuteProcess(


### PR DESCRIPTION
This pull request includes a minor change to the `generate_launch_description` function in `ci.launch.py`. The change fixes the formatting of the `gz_sim_command` list by removing an unnecessary space before the `--headless` argument.

* [`src/px4_ci_aws/launch/ci.launch.py`](diffhunk://#diff-7f4147c417d9dd7b5bb5d4663c4ef0198a8532921a3dc079e153d8d2dddaeb6cL93-R93): Adjusted the `gz_sim_command` list to ensure proper formatting of the `--headless` argument.