### PR TITLE
fix: using PX4_GZ_MODEL_NAME

### DIFF
--- a/src/px4_ci_aws/launch/ci.launch.py
+++ b/src/px4_ci_aws/launch/ci.launch.py
@@ -73,7 +73,7 @@ def generate_launch_description():
     px4_launch_command = (
         "cd /workspaces/px4_sitl_on_aws/PX4-Autopilot && sleep 2 &&"
         + " HEADLESS=1 PX4_SYS_AUTOSTART=4001"
-        + " PX4_SIM_MODEL=gz_x500 ./build/px4_sitl_default/bin/px4"
+        + " PX4_GZ_MODEL_NAME=gz_x500 ./build/px4_sitl_default/bin/px4"
     )
 
     px4_proc = ExecuteProcess(


### PR DESCRIPTION
This pull request updates the `ci.launch.py` file to fix an environment variable used in the PX4 launch command. The change ensures compatibility with the updated PX4 simulation model configuration.

Key change:

* In the `generate_launch_description` function, replaced the `PX4_SIM_MODEL` environment variable with `PX4_GZ_MODEL_NAME` in the `px4_launch_command` string to align with the updated naming convention for specifying the simulation model. (`[src/px4_ci_aws/launch/ci.launch.pyL76-R76](diffhunk://#diff-7f4147c417d9dd7b5bb5d4663c4ef0198a8532921a3dc079e153d8d2dddaeb6cL76-R76)`)