### PR TITLE
fix: add state machine offboard time parameter

### DIFF
--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -26,6 +26,12 @@ on:
         default: 120.0
         type: number
 
+      offboard_time_s:
+        description: "Time in seconds to stay in OFFBOARD mode before RTL [10.0, 120.0]"
+        required: true
+        default: 30.0
+        type: number
+
 jobs:
   build:
     name: Build Docker image
@@ -86,6 +92,7 @@ jobs:
           echo "Altitude: ${{ inputs.altitude }}"
           echo "Angular Velocity: ${{ inputs.angular_velocity }}"
           echo "Duration: ${{ inputs.duration }}"
+          echo "Offboard Time: ${{ inputs.offboard_time_s }}"
           echo "Running simulation..."
           docker pull 718459739973.dkr.ecr.eu-west-1.amazonaws.com/px4_sitl_on_aws:latest
           docker run --net=host --ipc=host --privileged \
@@ -94,6 +101,7 @@ jobs:
                 -e ALTITUDE=${{ inputs.altitude }} \
                 -e OMEGA=${{ inputs.angular_velocity }} \
                 -e TIMEOUT_S=${{ inputs.duration }} \
+                -e OFFBOARD_TIME_S=${{ inputs.offboard_time_s }} \
                 718459739973.dkr.ecr.eu-west-1.amazonaws.com/px4_sitl_on_aws:latest
 
       - name: Report

--- a/docs/px4_state_machine.md
+++ b/docs/px4_state_machine.md
@@ -1,0 +1,43 @@
+# PX4 State Machine Node
+
+This document explains the logic and flow of the `px4_state_machine.py` ROS 2 node, which automates arming, offboard mode, and RTL (Return to Launch) for PX4 SITL.
+
+## Overview
+
+The node manages the following states:
+- **INIT**: Waits for vehicle status.
+- **ARMING**: Sends arm command.
+- **ARMED**: Sends offboard command.
+- **OFFBOARD**: Waits in offboard mode for a configurable time.
+- **RTL**: Sends RTL command.
+- **DONE**: Mission complete.
+
+The time spent in OFFBOARD mode is controlled by the ROS 2 parameter `offboard_time_s` (default: 30.0s).
+
+## Parameters
+- `offboard_time_s` (double, default: 30.0): Time in seconds to stay in OFFBOARD mode before triggering RTL. Can be set via environment variable `OFFBOARD_TIME_S`.
+
+## Logic Flow
+
+```mermaid
+graph TD
+    INIT([INIT: Wait for vehicle_status]) --> ARMING([ARMING: Send ARM command])
+    ARMING -->|If armed| ARMED([ARMED: Send OFFBOARD command])
+    ARMED -->|If in offboard| OFFBOARD([OFFBOARD: Wait offboard_time_s])
+    OFFBOARD -->|If delta_time_s > offboard_time_s| RTL([RTL: Send RTL command])
+    RTL -->|If disarmed| DONE([DONE: Mission complete])
+```
+
+## State Descriptions
+- **INIT**: Waits for the first `vehicle_status` message.
+- **ARMING**: Sends an arm command until the vehicle is armed.
+- **ARMED**: Sends an offboard command until the vehicle enters offboard mode.
+- **OFFBOARD**: Waits for `offboard_time_s` seconds in offboard mode.
+- **RTL**: Sends RTL command once, waits for disarm.
+- **DONE**: Mission is complete, node exits.
+
+## Usage
+- The node is launched via `ci.launch.py` and can be configured with the `OFFBOARD_TIME_S` environment variable.
+
+---
+*Generated on 2025-04-19*

--- a/scripts/simulation.sh
+++ b/scripts/simulation.sh
@@ -12,5 +12,6 @@ echo "Radius: $RADIUS"
 echo "Altitude: $ALTITUDE"
 echo "Omega: $OMEGA"
 echo "Timeout: $TIMEOUT_S"
+echo "Offboard Time: $OFFBOARD_TIME_S"
 
 ros2 launch px4_ci_aws ci.launch.py

--- a/src/px4_ci_aws/launch/ci.launch.py
+++ b/src/px4_ci_aws/launch/ci.launch.py
@@ -62,11 +62,13 @@ radius = safe_float("RADIUS", 10.0)
 altitude = safe_float("ALTITUDE", 30.0)
 omega = safe_float("OMEGA", 0.5)
 timeout_s = safe_float("TIMEOUT_S", 120.0)
+offboard_time_s = safe_float("OFFBOARD_TIME_S", 30.0)
 
 logging.info(f"Radius: {radius}")
 logging.info(f"Altitude: {altitude}")
 logging.info(f"Omega: {omega}")
 logging.info(f"Timeout: {timeout_s}")
+logging.info(f"Offboard Time: {offboard_time_s}")
 
 def generate_launch_description():
 
@@ -111,6 +113,7 @@ def generate_launch_description():
             package='px4_ci_aws',
             executable='px4_state_machine.py',
             name='px4_state_machine',
+            parameters=[{'offboard_time_s': offboard_time_s}],
         )
     
     node_offboard = Node(

--- a/src/px4_ci_aws/src/px4_state_machine.py
+++ b/src/px4_ci_aws/src/px4_state_machine.py
@@ -31,6 +31,8 @@ class ArmOffboardNode(Node):
         self.offboard_state = OffboardState.INIT
         self.rtl_triggered = False
 
+        self.offboard_time_s = self.declare_parameter('offboard_time_s', 30.0).value
+
         qos_profile = QoSProfile(
             reliability=QoSReliabilityPolicy.BEST_EFFORT,
             durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
@@ -82,7 +84,7 @@ class ArmOffboardNode(Node):
             self.get_logger().info("Vehicle is armed and in OFFBOARD mode.", throttle_duration_sec=5.0)
             current_time_s = self.get_clock().now().seconds_nanoseconds()[0] + self.get_clock().now().seconds_nanoseconds()[1] / 1e9
             delta_time_s = current_time_s - self.offboard_init_time_s
-            if delta_time_s > 30.0:
+            if delta_time_s > self.offboard_time_s:
                 self.offboard_state = OffboardState.RTL
                 self.get_logger().info("RTL command will be sent.", throttle_duration_sec=5.0)
         


### PR DESCRIPTION
This pull request introduces a new configurable parameter, `offboard_time_s`, to control the duration a PX4 vehicle stays in OFFBOARD mode before transitioning to RTL (Return to Launch). The changes span workflow configuration, documentation, and code updates to support this parameter.

### Workflow Configuration Updates:
* Added a new input parameter, `offboard_time_s`, to the GitHub Actions workflow (`.github/workflows/sitl.yml`). This parameter is required, with a default value of 30.0 seconds, and is passed as an environment variable to the simulation. [[1]](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R29-R34) [[2]](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R95) [[3]](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R104)

### Documentation Updates:
* Created a new document, `docs/px4_state_machine.md`, detailing the PX4 state machine logic, including the role of the `offboard_time_s` parameter in controlling the OFFBOARD mode duration. Includes a mermaid diagram for state transitions and usage instructions.

### Code Updates:
* Updated `scripts/simulation.sh` to log the value of `OFFBOARD_TIME_S` during simulation runs.
* Enhanced the ROS 2 launch file (`src/px4_ci_aws/launch/ci.launch.py`) to read the `OFFBOARD_TIME_S` environment variable, log its value, and pass it as a parameter to the `px4_state_machine.py` node. [[1]](diffhunk://#diff-7f4147c417d9dd7b5bb5d4663c4ef0198a8532921a3dc079e153d8d2dddaeb6cR65-R71) [[2]](diffhunk://#diff-7f4147c417d9dd7b5bb5d4663c4ef0198a8532921a3dc079e153d8d2dddaeb6cR116)
* Modified the `px4_state_machine.py` node to declare and use the `offboard_time_s` parameter, replacing the hardcoded value of 30.0 seconds for OFFBOARD mode duration. [[1]](diffhunk://#diff-e509586ca298b88155a5b5533d7d8e16967b67b3666f90ea5e301504514fee6eR34-R35) [[2]](diffhunk://#diff-e509586ca298b88155a5b5533d7d8e16967b67b3666f90ea5e301504514fee6eL85-R87)