### PR TITLE
ci: add new tag workflow

### DIFF
--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -1,5 +1,8 @@
 name: Software in the Loop
 on:
+  push:
+    tags:
+      - 'v*'  
   workflow_dispatch:
     inputs:
       radius:
@@ -105,7 +108,10 @@ jobs:
                 718459739973.dkr.ecr.eu-west-1.amazonaws.com/px4_sitl_on_aws:latest
 
       - name: Report
-        run: cat ~/bags/topic_report.txt
+        run: |
+          cat ~/bags/topic_report.txt
+          current_time=$(date +"%Y-%m-%d_%H-%M-%S")
+          mv ~/bags/topic_report.txt ~/bags/topic_report_${current_time}.txt
           
       - name: Install AWS CLI and upload the bags
         run: |

--- a/.github/workflows/version-and-tag.yml
+++ b/.github/workflows/version-and-tag.yml
@@ -1,0 +1,70 @@
+name: Tag New Version
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: get_tag
+        run: |
+          git fetch --tags
+          tag=$(git describe --tags --abbrev=0 || echo "v0.0.0")
+          echo "latest=$tag" >> $GITHUB_OUTPUT
+
+      - name: Determine bump type from PR label
+        id: bump
+        run: |
+          label=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+              | jq -r '.[].name' | grep '^release:' || true)
+
+          echo "Label: $label"
+
+          case "$label" in
+            release:major) bump="major" ;;
+            release:minor) bump="minor" ;;
+            release:patch) bump="patch" ;;
+            *) echo "No valid release label found"; exit 1 ;;
+          esac
+
+          echo "bump=$bump" >> $GITHUB_OUTPUT
+
+      - name: Bump version and create tag
+        id: bump_tag
+        run: |
+          old="${{ steps.get_tag.outputs.latest }}"
+          echo "Previous tag: $old"
+
+          # Strip "v" and split
+          version="${old#v}"
+          IFS='.' read -r major minor patch <<< "$version"
+
+          case "${{ steps.bump.outputs.bump }}" in
+            major) ((major++)); minor=0; patch=0 ;;
+            minor) ((minor++)); patch=0 ;;
+            patch) ((patch++)) ;;
+          esac
+
+          new_tag="v$major.$minor.$patch"
+          echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
+
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git tag "$new_tag"
+          git push origin "$new_tag"
+
+      - name: Output new tag
+        run: echo "Tagged ${{ steps.bump_tag.outputs.new_tag }}"


### PR DESCRIPTION
This pull request introduces improvements to the CI workflows by adding automated tagging for new releases and enhancing the SITL workflow for better file handling and triggering. The most significant changes include the addition of a new workflow for version tagging, updates to the SITL workflow to trigger on tag pushes, and enhancements to the SITL report handling.

### New version tagging workflow:

* [`.github/workflows/version-and-tag.yml`](diffhunk://#diff-9c983361de27f28d4caed4a11787794ab0c3aa7b75ba7b99c22fbfdf2448c848R1-R70): Added a new workflow to automatically tag new versions when pull requests are merged into the `main` branch. The workflow determines the version bump type (major, minor, or patch) based on PR labels and creates a corresponding new tag.

### SITL workflow enhancements:

* [`.github/workflows/sitl.yml`](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R3-R5): Updated the workflow to trigger on tag pushes matching the pattern `v*`, enabling SITL runs for versioned releases.
* [`.github/workflows/sitl.yml`](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602L108-R114): Enhanced the "Report" step to include a timestamp in the report file name, ensuring unique file names for each run.