### PR TITLE
ci(tag): use repo token

### DIFF
--- a/.github/workflows/version-and-tag.yml
+++ b/.github/workflows/version-and-tag.yml
@@ -18,8 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Ensure we're on the main branch
-        run: |
-          git checkout main
+        run: git checkout main
 
       - name: Get latest tag
         id: get_tag
@@ -32,8 +31,8 @@ jobs:
         id: bump
         run: |
           label=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
-              | jq -r '.[].name' | grep '^release:' || true)
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+            | jq -r '.[].name' | grep '^release:' || true)
 
           echo "Label: $label"
 
@@ -71,9 +70,7 @@ jobs:
             echo "Tag $new_tag already exists"
           else
             git tag "$new_tag"
-            git push origin "$new_tag"
-            # Alternative with PAT:
-            # git push https://${{ secrets.REPO_TOKEN }}@github.com/${{ github.repository }} "$new_tag"
+            git push https://x-access-token:${{ secrets.REPO_TOKEN }}@github.com/${{ github.repository }} "$new_tag"
           fi
 
       - name: Output new tag


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/version-and-tag.yml` file to improve the GitHub Actions workflow. The changes focus on simplifying commands and enhancing security for pushing tags.

### Workflow simplifications:
* Removed unnecessary multi-line syntax in the `Ensure we're on the main branch` step, replacing it with a single-line `git checkout main` command.

### Security improvements:
* Updated the `git push` command to use a token-based authentication method (`x-access-token`) instead of plain `git push origin`, ensuring secure access to the repository when pushing tags.