### PR TITLE
ci(tag): use repo token

### DIFF
--- a/.github/workflows/version-and-tag.yml
+++ b/.github/workflows/version-and-tag.yml
@@ -49,12 +49,14 @@ jobs:
         id: bump_tag
         run: |
           old="${{ steps.get_tag.outputs.latest }}"
+          bump="${{ steps.bump.outputs.bump }}"
           echo "Previous tag: $old"
+          echo "Bump type: $bump"
 
           version="${old#v}"
           IFS='.' read -r major minor patch <<< "$version"
 
-          case "${{ steps.bump.outputs.bump }}" in
+          case "$bump" in
             major) ((major++)); minor=0; patch=0 ;;
             minor) ((minor++)); patch=0 ;;
             patch) ((patch++)) ;;


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/version-and-tag.yml` file. The change simplifies the handling of the bump type by introducing a new variable `bump` and reusing it in both the `echo` statement and the `case` statement.