### PR TITLE
fix(ci.launch.py): better run report

### DIFF
--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -113,9 +113,9 @@ jobs:
 
       - name: Report
         run: |
-          cat ~/bags/topic_report.txt
+          cat ~/bags/topic_report.md
           current_time=$(date +"%Y-%m-%d_%H-%M-%S")
-          mv ~/bags/topic_report.txt ~/bags/topic_report_${current_time}.txt
+          mv ~/bags/topic_report.md ~/bags/topic_report_${current_time}.md
           
       - name: Install AWS CLI and upload the bags
         run: |


### PR DESCRIPTION
This pull request enhances the post-processing of simulation bag files in the `src/px4_ci_aws/launch/ci.launch.py` script. The changes improve the analysis and reporting of bag file data by introducing a detailed Markdown report with additional metadata and warnings for low-message topics.

### Enhancements to bag file analysis and reporting:

* **Detailed Markdown Report Generation**:
  - Added a Markdown report summarizing the bag file's metadata, including the total number of topics, total messages, simulation start and end times, and duration.
  - Included a table of message counts by topic, with warnings for topics with fewer than 10 messages.
  - Added a warnings section highlighting topics with no or low message counts.

* **Improved Metadata Extraction**:
  - Extracted and formatted simulation start and end timestamps using UTC time, and calculated the duration of the simulation.

### Code improvements:

* **Refactoring for Readability**:
  - Replaced inline `Path(bag_name)` with a `bag_path` variable for clarity.
  - Removed the old plain-text report generation in favor of the new Markdown format.

* **New Imports**:
  - Added `datetime` to handle timestamp formatting and duration calculations.