### PR TITLE
fix(sitl.yml): renaming jobs

### DIFF
--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -52,7 +52,7 @@ on:
 
 jobs:
     start-runner:
-      name: Start self-hosted EC2 runner
+      name: Start EC2
       runs-on: ubuntu-latest
       outputs:
         label: ${{ steps.start-ec2-runner.outputs.label }}
@@ -77,7 +77,7 @@ jobs:
             iam-role-name: px4_sitl_on_aws     
 
     do-the-job:
-      name: Run SITL from Docker Image
+      name: Run SITL
       needs: start-runner
       runs-on: ${{ needs.start-runner.outputs.label }}
       outputs:
@@ -137,7 +137,7 @@ jobs:
           run: echo "s3_path=s3://px4-sitl-on-aws-bags/" >> "$GITHUB_OUTPUT"
 
     stop-runner:
-      name: Stop self-hosted EC2 runner
+      name: Stop EC2
       needs:
         - start-runner
         - do-the-job


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/sitl.yml` file, simplifying job names for better readability and consistency.

Workflow job name updates:

* Renamed `start-runner` job from "Start self-hosted EC2 runner" to "Start EC2" for brevity. (`[.github/workflows/sitl.ymlL55-R55](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602L55-R55)`)
* Renamed `do-the-job` job from "Run SITL from Docker Image" to "Run SITL" to streamline the name. (`[.github/workflows/sitl.ymlL80-R80](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602L80-R80)`)
* Renamed `stop-runner` job from "Stop self-hosted EC2 runner" to "Stop EC2" for consistency with the `start-runner` job. (`[.github/workflows/sitl.ymlL140-R140](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602L140-R140)`)