### PR TITLE
ci: working for manually dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
     name: Build Docker image
     uses: ./.github/workflows/build.yml
     secrets:
@@ -20,6 +21,13 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
+
+  wait-for-build:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: always()
+    steps:
+      - run: echo "Proceeding after optional build step"
 
   sitl:
     name: Software in the Loop
@@ -29,7 +37,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
-    needs: build
+    needs: [wait-for-build]
 
   data:
     name: Run Bag Analysis
@@ -45,6 +53,7 @@ jobs:
 
   release:
     name: Trigger GitHub Release
+    if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
     uses: ./.github/workflows/release.yml
     needs: data
     with:

--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -37,10 +37,10 @@ jobs:
 
       - name: Download bag file from S3
         run: |
-          mkdir -p bag_data
+          mkdir -p data
           echo "Downloading bag file from S3..."
           echo "S3 path: ${{ inputs.s3_path }}"
-          aws s3 cp "${{ inputs.s3_path }}" ./bag_data/ --recursive
+          aws s3 cp "${{ inputs.s3_path }}" ./data/ --recursive
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run bag analysis
         run: |
-          python3 ./scripts/bag_analysis.py ./bag_data
+          python3 ./scripts/bag_analysis.py ./data
           echo "Analysis complete."
 
       - name: Commit and push analysis result


### PR DESCRIPTION
This pull request introduces changes to the GitHub Actions workflows to improve flexibility and organization, as well as updates the directory structure used in the data processing workflow. Key changes include adding conditional triggers for specific jobs, introducing a new `wait-for-build` job, and updating directory paths in the data workflow.

### Workflow Enhancements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR16): Added conditional triggers (`if` statements) for the `build` and `release` jobs to ensure they only run on `push` or `repository_dispatch` events. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR16) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR56)
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR25-R31): Introduced a new `wait-for-build` job that always runs after the `build` job, providing a buffer step before dependent jobs. Updated the `sitl` and `data` jobs to depend on `wait-for-build` instead of `build`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR25-R31) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL32-R40)

### Data Workflow Updates:

* [`.github/workflows/data.yml`](diffhunk://#diff-5dac0ea71aa88b386dd3e9c6f2b6b81bb6e2bb7f9e6802d671bbf302d0b87141L40-R51): Changed the directory name from `bag_data` to `data` for downloading and processing files, ensuring consistency across steps in the workflow.