### PR TITLE
fix(ci.yml): workflow_dispatch patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ on:
 
 jobs:
   build:
-    if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
     name: Build Docker image
     uses: ./.github/workflows/build.yml
+    if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
     secrets:
       REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -32,17 +32,20 @@ jobs:
   sitl:
     name: Software in the Loop
     uses: ./.github/workflows/sitl.yml
+    needs: [wait-for-build]
+    if: always()
     secrets:
       REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
-    needs: [wait-for-build]
+
 
   data:
     name: Run Bag Analysis
     uses: ./.github/workflows/data.yml
     needs: sitl
+    if: always()
     with:
       s3_path: ${{ needs.sitl.outputs.s3_path }}
     secrets:
@@ -53,9 +56,9 @@ jobs:
 
   release:
     name: Trigger GitHub Release
-    if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
     uses: ./.github/workflows/release.yml
     needs: data
+    if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
     with:
       tag: ${{ github.ref_name }}
     secrets:


### PR DESCRIPTION
This pull request modifies the `.github/workflows/ci.yml` file to improve the configuration of conditional job execution and dependencies in the CI pipeline. The changes primarily focus on refining the `if` conditions and `needs` relationships for better clarity and functionality.

### Workflow Configuration Updates:

* **Standardized `if` Conditions Across Jobs**:
  - Updated the `if` condition for the `build` and `release` jobs to ensure consistent behavior when triggered by `push` or `repository_dispatch` events. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL16-R18) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL56-R61)
  - Added `if: always()` to the `sitl` and `data` jobs to ensure these jobs execute regardless of the outcome of preceding jobs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR35-R48) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR35-R48)

* **Refined `needs` Dependencies**:
  - Adjusted the `needs` attribute for the `sitl` job to ensure it correctly depends on the `wait-for-build` job.