### PR TITLE
fix(bag_analysis): correct name

### DIFF
--- a/scripts/bag_analysis.py
+++ b/scripts/bag_analysis.py
@@ -16,7 +16,7 @@ def main():
     results_dir = "results"
     os.makedirs(results_dir, exist_ok=True)
 
-    report_path = os.path.join(results_dir, f"{bag_path}_report.md")
+    report_path = os.path.join(results_dir, f"{os.path.basename(bag_path)}_report.md")
     with open(report_path, "w") as f:
         f.write("# Bag Analysis Report\n\n")
         f.write(f"Hello, world!\n\n")


### PR DESCRIPTION
This pull request includes a minor improvement to the `scripts/bag_analysis.py` script. The change ensures that the generated report file uses only the base name of the `bag_path`, rather than the full path, in its filename.

* [`scripts/bag_analysis.py`](diffhunk://#diff-4d58038f206bceb9f2134cc6e30fec87cd57f49a1ee09dc58b977ff9083017bfL19-R19): Updated the `report_path` variable to use `os.path.basename(bag_path)` so that the report filename includes only the base name of the `bag_path`, improving clarity and avoiding potential issues with directory paths.