### PR TITLE
fix(data.yml): correct git add

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -56,6 +56,6 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add '**/results/*.md'
+          git add results/*.md
           git commit -m "docs: add bag analysis report from ${{ inputs.bag_file_name }}"
           git push


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/data.yml` file. The change simplifies the file path pattern used in the `git add` command.

* [`.github/workflows/data.yml`](diffhunk://#diff-5dac0ea71aa88b386dd3e9c6f2b6b81bb6e2bb7f9e6802d671bbf302d0b87141L59-R59): Updated the `git add` command to use a more specific file path (`results/*.md` instead of `**/results/*.md`) to match Markdown files directly under the `results` directory.