### PR TITLE
fix: data workflow push to main

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -58,4 +58,4 @@ jobs:
           git config user.email "github-actions@github.com"
           git add results/*.md
           git commit -m "docs: add bag analysis report from ${{ inputs.bag_file_name }}"
-          git push
+          git push origin main


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/data.yml` file. The change updates the `git push` command to explicitly specify the `main` branch as the target.

* [`.github/workflows/data.yml`](diffhunk://#diff-5dac0ea71aa88b386dd3e9c6f2b6b81bb6e2bb7f9e6802d671bbf302d0b87141L61-R61): Changed `git push` to `git push origin main` to ensure the push operation targets the correct branch.