### PR TITLE
fix(build): caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,17 +51,6 @@ jobs:
         run: |
           docker pull 718459739973.dkr.ecr.eu-west-1.amazonaws.com/px4_sitl_on_aws:latest
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: docker-cache-${{ runner.os }}-${{ github.ref_name }}
-          restore-keys: |
-            docker-cache-${{ runner.os }}-
-
       - name: Build and push simulation image
         run: |
           ./scripts/build_sim.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,28 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 
+
+      - name: Get Tag Commit SHA
+        id: get_tag_commit
+        run: |
+          echo "Fetching tag commit..."
+          commit_sha=$(git rev-list -n 1 ${{ inputs.tag }})
+          echo "commit_sha=$commit_sha" >> $GITHUB_OUTPUT
 
       - name: Get Latest Report From results Folder
         id: get_latest_report
         run: |
           echo "Fetching latest report..."
           latest_report=$(ls -t results/*.pdf | head -n 1)
-          echo "Latest report: $latest_report"
           echo "report_path=$latest_report" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag }}
+          target_commitish: ${{ steps.get_tag_commit.outputs.commit_sha }}
           generate_release_notes: true
           files: ${{ steps.get_latest_report.outputs.report_path }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
           echo "Fetching latest report..."
           latest_report=$(ls -t results/*.pdf | head -n 1)
           echo "Latest report: $latest_report"
-          echo "report_path=$latest_report" >> $GITHUB_ENV
+          echo "report_path=$latest_report" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag }}
           generate_release_notes: true
-          files: $latest_report
+          files: ${{ steps.get_latest_report.outputs.report_path }}
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}

--- a/scripts/build_sim.sh
+++ b/scripts/build_sim.sh
@@ -12,11 +12,7 @@ image="$registry/$repo:$timestamp"
 
 echo "Building image: $image"
 
-docker buildx create --use --name builder || docker buildx use builder
-
-docker buildx build \
-  --cache-from=type=local,src=/tmp/.buildx-cache \
-  --cache-to=type=local,dest=/tmp/.buildx-cache,mode=max \
+docker build \
   --push \
   -t "$image" \
   -t "$registry/$repo:latest" \

--- a/scripts/report_single.py
+++ b/scripts/report_single.py
@@ -77,7 +77,7 @@ class SingleReport:
         plt.axis('off')
 
         plt.text(
-            0.5, 0.8, "Bag Report",
+            0.5, 0.8, "Run Report",
             ha='center', va='center',
             fontsize=24,
             fontweight='bold',

--- a/scripts/report_single.py
+++ b/scripts/report_single.py
@@ -84,12 +84,10 @@ class SingleReport:
         )
 
         commit_short = self.commit_id[:8] if self.commit_id not in "N/A" else "N/A"
-        commit_url = f"https://github.com/iftahnaf/px4_sitl_on_aws/commit/{self.commit_id}" if self.commit_id not in "N/A" else ""
-        commit_md = f"[{commit_short}]({commit_url})" if self.commit_id not in "N/A" else "N/A"
         metadata_text = (
             f"Bag File: {os.path.basename(self.bag_path)}\n"
             f"Generated on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
-            f"Commit: {commit_md}\n"
+            f"Commit: {commit_short}\n"
             f"Author: {self.author}\n\n"
         )
 


### PR DESCRIPTION
This pull request introduces updates to CI/CD workflows, Docker image building, and report generation. Key changes include simplifying Docker build processes, improving GitHub Actions workflows for releases, and refining the report generation script for better clarity and functionality.

### CI/CD Workflow Improvements:
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L54-L64): Removed the setup for Docker Buildx and Docker layer caching to simplify the build process.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R20-R43): Added steps to fetch the tag commit SHA and updated the `target_commitish` field in the GitHub release process. Changed the mechanism for passing the latest report path to use `GITHUB_OUTPUT` instead of `GITHUB_ENV`.

### Docker Image Building Simplifications:
* [`scripts/build_sim.sh`](diffhunk://#diff-c46a371b704d5c4392fba351f516e950824a6fc208eafb6fabfcaa8275e17ca3L15-R15): Replaced the use of Docker Buildx with a standard `docker build` command, removing caching configurations for a more straightforward build process.

### Report Generation Enhancements:
* [`scripts/report_single.py`](diffhunk://#diff-7aa05f5e64147b1d35faa65f1530e3ae4fc727200fa8ecb6ae4e443cd441eb32L80-R90): Updated the summary page title from "Bag Report" to "Run Report" and simplified the commit metadata display by removing the commit URL and markdown formatting.