### PR TITLE
fix(release): setting prerelease as true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,5 +41,6 @@ jobs:
           target_commitish: ${{ steps.get_tag_commit.outputs.commit_sha }}
           generate_release_notes: true
           files: ${{ steps.get_latest_report.outputs.report_path }}
+          prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}

--- a/scripts/report_single.py
+++ b/scripts/report_single.py
@@ -77,7 +77,7 @@ class SingleReport:
         plt.axis('off')
 
         plt.text(
-            0.5, 0.8, "Run Report",
+            0.5, 0.8, "Single Run Report",
             ha='center', va='center',
             fontsize=24,
             fontweight='bold',


### PR DESCRIPTION
This pull request includes two changes: one to the release workflow configuration and another to the report generation script. The changes focus on improving the release process and clarifying report titles.

### Workflow Configuration:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R44): Added the `prerelease: true` field to mark releases as pre-releases by default.

### Report Generation:
* [`scripts/report_single.py`](diffhunk://#diff-7aa05f5e64147b1d35faa65f1530e3ae4fc727200fa8ecb6ae4e443cd441eb32L80-R80): Updated the title text in the `add_summary_page` method from "Run Report" to "Single Run Report" for improved clarity.