### PR TITLE
feat(run.yml): manual dispatch sitl and data workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
     uses: ./.github/workflows/sitl.yml
     needs: [wait-for-build]
     if: always()
+    with:
+      radius: 30.0
+      altitude: 30.0
+      angular_velocity: 0.5
+      duration: 120.0
+      offboard_time_s: 30.0
     secrets:
       REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025, Iftach Naftaly <iftahnaf@gmail.com>
+name: Run
+on:
+  workflow_dispatch:
+    inputs:
+      radius:
+        description: "Radius of the circle in meters [10.0, 50.0]"
+        required: true
+        default: 30.0
+        type: number
+
+      altitude:
+        description: "Altitude of the circle in meters [10.0, 50.0]"
+        required: true
+        default: 30.0
+        type: number
+
+      angular_velocity:
+        description: "Angular velocity of the drone in rad/s [0.2, 1.0]"
+        required: true
+        default: 0.5
+        type: number
+
+      duration:
+        description: "Duration of the simulation in seconds [120.0, 300.0]"
+        required: true
+        default: 120.0
+        type: number
+
+      offboard_time_s:
+        description: "Time in seconds to stay in OFFBOARD mode before RTL [10.0, 120.0]"
+        required: true
+        default: 30.0
+        type: number
+
+jobs:
+  sitl:
+    name: Software in the Loop
+    uses: ./.github/workflows/sitl.yml
+    with:
+      radius: ${{ inputs.radius }}
+      altitude: ${{ inputs.altitude }}
+      angular_velocity: ${{ inputs.angular_velocity }}
+      duration: ${{ inputs.duration }}
+      offboard_time_s: ${{ inputs.offboard_time_s }}
+    secrets:
+      REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+
+  data:
+    name: Run Bag Analysis
+    uses: ./.github/workflows/data.yml
+    needs: sitl
+    if: always()
+    with:
+      s3_path: ${{ needs.sitl.outputs.s3_path }}
+      bag_file_name: ${{ needs.sitl.outputs.bag_file_name }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      REPO_TOKEN: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -13,6 +13,32 @@ on:
       AWS_REGION:
         required: true
 
+    inputs:
+      radius:
+        description: "Radius of the circle in meters [10.0, 50.0]"
+        required: true
+        type: number
+
+      altitude:
+        description: "Altitude of the circle in meters [10.0, 50.0]"
+        required: true
+        type: number
+
+      angular_velocity:
+        description: "Angular velocity of the drone in rad/s [0.2, 1.0]"
+        required: true
+        type: number
+
+      duration:
+        description: "Duration of the simulation in seconds [120.0, 300.0]"
+        required: true
+        type: number
+
+      offboard_time_s:
+        description: "Time in seconds to stay in OFFBOARD mode before RTL [10.0, 120.0]"
+        required: true
+        type: number  
+
     outputs:
       s3_path:
         description: "The full S3 path to the uploaded bag"
@@ -21,38 +47,6 @@ on:
         description: "The name of the bag file"
         value: ${{ jobs.do-the-job.outputs.bag_file_name }}
         
-  workflow_dispatch:
-    inputs:
-      radius:
-        description: "Radius of the circle in meters [10.0, 50.0]"
-        required: true
-        default: 30.0
-        type: number
-
-      altitude:
-        description: "Altitude of the circle in meters [10.0, 50.0]"
-        required: true
-        default: 30.0
-        type: number
-
-      angular_velocity:
-        description: "Angular velocity of the drone in rad/s [0.2, 1.0]"
-        required: true
-        default: 0.5
-        type: number
-
-      duration:
-        description: "Duration of the simulation in seconds [120.0, 300.0]"
-        required: true
-        default: 120.0
-        type: number
-
-      offboard_time_s:
-        description: "Time in seconds to stay in OFFBOARD mode before RTL [10.0, 120.0]"
-        required: true
-        default: 30.0
-        type: number
-
 jobs:
     start-runner:
       name: Start EC2


### PR DESCRIPTION
This pull request introduces updates to GitHub Actions workflows to enhance configurability and streamline the execution of simulation and data analysis jobs. Key changes include the addition of new input parameters, restructuring of workflows, and improved output handling.

### Enhancements to GitHub Actions workflows:

* **New `run.yml` workflow**: Added a new workflow (`.github/workflows/run.yml`) to allow manual triggering with configurable parameters such as `radius`, `altitude`, `angular_velocity`, `duration`, and `offboard_time_s`. This workflow orchestrates a simulation job (`sitl`) and a subsequent data analysis job (`data`) with dependency management.

* **Parameterization of `sitl.yml`**: Updated the `sitl.yml` workflow to include new input parameters (`radius`, `altitude`, `angular_velocity`, `duration`, `offboard_time_s`) for greater flexibility in simulation configuration.

### Workflow restructuring:

* **Reorganization of `sitl.yml` inputs and outputs**: Moved the `workflow_dispatch` inputs and default values from `sitl.yml` to the new `run.yml` workflow. Outputs (`s3_path` and `bag_file_name`) were also restructured for better modularity and compatibility with downstream jobs.