### PR TITLE
fix(sitl.yml): multi_run pass as boolean

### DIFF
--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -189,7 +189,7 @@ jobs:
       with:
         s3_path: ${{ needs.do-the-job.outputs.s3_path }}
         bag_file_name: ${{ needs.do-the-job.outputs.bag_file_name }}
-        multi_run: ${{ inputs.number_of_runs != '1' && 'true' || 'false' }}
+        multi_run: ${{ inputs.number_of_runs != '1' && true || false }}
       secrets:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/sitl.yml` file. The change simplifies the `multi_run` expression by using boolean values (`true` and `false`) directly instead of strings.

* [`.github/workflows/sitl.yml`](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602L192-R192): Updated the `multi_run` parameter to use boolean values (`true` and `false`) instead of string equivalents (`'true'` and `'false'`).