### PR TITLE
fix(ci): parent bag folder for multi run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     needs: sitl
     if: always()
     with:
-      s3_path: ${{ needs.sitl.outputs.s3_path }}
+      bag_path: ${{ needs.sitl.outputs.bag_path }}
       bag_file_name: ${{ needs.sitl.outputs.bag_file_name }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -5,7 +5,7 @@ name: Analyze Bag Data
 on:
   workflow_call:
     inputs:
-      s3_path:
+      bag_path:
         required: true
         type: string
       bag_file_name:
@@ -46,9 +46,9 @@ jobs:
           mkdir -p data
           echo "Downloading bag files from S3..."
           if [ "${{ inputs.multi_run }}" = "true" ]; then
-            aws s3 cp "${{ inputs.s3_path }}" ./data --recursive
+            aws s3 cp "${{ inputs.bag_path }}" ./data --recursive
           else
-            aws s3 cp "${{ inputs.s3_path }}${{ inputs.bag_file_name }}" ./data/${{ inputs.bag_file_name }} --recursive
+            aws s3 cp "${{ inputs.bag_path }}${{ inputs.bag_file_name }}" ./data/${{ inputs.bag_file_name }} --recursive
           fi
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -70,7 +70,8 @@ jobs:
       - name: Run Multi bag analysis
         if: ${{ inputs.multi_run == true }}
         run: |
-          python3 ./scripts/report_multi.py ./data/${{ inputs.s3_path }} --commit_id ${{ github.sha }} --author ${{ github.actor }}
+          folder_name=$(basename "${{ inputs.bag_path }}")
+          python3 ./scripts/report_multi.py ./data/$folder_name --commit_id ${{ github.sha }} --author ${{ github.actor }}
           echo "Analysis complete."
 
       - name: Upload to Artifact

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -60,9 +60,19 @@ jobs:
           done
 
           echo "matrix={\"run_id\":[${matrix_values}]}" >> $GITHUB_OUTPUT
+
+  set-timestamp:
+    runs-on: ubuntu-latest
+    outputs:
+      folder: ${{ steps.timestamp.outputs.folder }}
+    steps:
+      - id: timestamp
+        run: |
+          echo "folder=px4-sitl-on-aws-bags/$(date +'%Y-%m-%d_%H-%M-%S')" >> "$GITHUB_OUTPUT"
+        
   sitl:
     name: Software in the Loop (Run ${{ matrix.run_id }})
-    needs: set-matrix
+    needs: [set-matrix, set-timestamp]
     strategy:
       max-parallel: 4
       matrix: 
@@ -77,6 +87,7 @@ jobs:
       seq: ${{ matrix.run_id }}
       on_job_analysis: true
       number_of_runs: ${{ inputs.number_of_runs }}
+      parent_folder: ${{ needs.set-timestamp.outputs.folder }}
     secrets:
       REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -54,10 +54,15 @@ on:
         default: "1"
         type: string
 
+      parent_folder:
+        description: "The parent folder for the bag files"
+        default: "px4-sitl-on-aws-bags"
+        type: string
+
     outputs:
-      s3_path:
-        description: "The full S3 path to the uploaded bag"
-        value: ${{ jobs.do-the-job.outputs.s3_path }}
+      bag_path:
+        description: "The full path to the uploaded bag"
+        value: ${{ jobs.do-the-job.outputs.bag_path }}
       bag_file_name:
         description: "The name of the bag file"
         value: ${{ jobs.do-the-job.outputs.bag_file_name }}
@@ -93,7 +98,7 @@ jobs:
       needs: start-runner
       runs-on: ${{ needs.start-runner.outputs.label }}
       outputs:
-        s3_path: ${{ steps.upload-bags.outputs.s3_path }}
+        bag_path: ${{ steps.upload-bags.outputs.bag_path }}
         bag_file_name: ${{ steps.set-bag-file-name.outputs.bag_file_name }}
       steps:
 
@@ -136,11 +141,9 @@ jobs:
                   718459739973.dkr.ecr.eu-west-1.amazonaws.com/px4_sitl_on_aws:latest
             echo "bag_file_name=$bag_file_name" >> "$GITHUB_OUTPUT"
 
-        - name: Topic Report
+        - name: Print Topic Report
           run: |
-            cat ~/bags/topic_report.md
-            current_time=$(date +"%Y-%m-%d_%H-%M-%S")
-            mv ~/bags/topic_report.md ~/bags/topic_report_${current_time}.md
+            cat ~/bags/topic_report.md            
 
         - name: Upload the bags to S3
           id: upload-bags
@@ -151,9 +154,10 @@ jobs:
             unzip awscliv2.zip
             sudo ./aws/install
             current_time=$(date +"%Y-%m-%d_%H-%M-%S")
-            export S3_FOLDER=px4-sitl-on-aws-bags/$current_time/
+            mv ~/bags/topic_report.md ~/bags/topic_report_${current_time}.md
+            export S3_FOLDER=${{ inputs.parent_folder }}/$current_time/
             aws s3 cp ~/bags "s3://$S3_FOLDER" --recursive
-            echo "s3_path=s3://$S3_FOLDER" >> "$GITHUB_OUTPUT"
+            echo "bag_path=s3://$S3_FOLDER" >> "$GITHUB_OUTPUT"
 
         - name: Set bag file name output
           id: set-bag-file-name
@@ -187,7 +191,7 @@ jobs:
       needs: [do-the-job]
       if: ${{ inputs.on_job_analysis && (inputs.number_of_runs == inputs.seq) }}
       with:
-        s3_path: ${{ needs.do-the-job.outputs.s3_path }}
+        bag_path: ${{ needs.do-the-job.outputs.bag_path }}
         bag_file_name: ${{ needs.do-the-job.outputs.bag_file_name }}
         multi_run: ${{ inputs.number_of_runs != '1' && true || false }}
       secrets:


### PR DESCRIPTION
This pull request introduces significant changes to the CI workflows to replace the term `s3_path` with `bag_path` for improved clarity and consistency. Additionally, it adds functionality to dynamically set a timestamped folder for organizing bag files. Below are the most important changes grouped by theme:

### Terminology Update (`s3_path` to `bag_path`):

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL56-R56): Replaced `s3_path` with `bag_path` in the `needs.sitl.outputs` and updated the corresponding input parameter.
* [`.github/workflows/data.yml`](diffhunk://#diff-5dac0ea71aa88b386dd3e9c6f2b6b81bb6e2bb7f9e6802d671bbf302d0b87141L8-R8): Updated all occurrences of `s3_path` to `bag_path` in workflow inputs and AWS S3 commands for downloading bag files. [[1]](diffhunk://#diff-5dac0ea71aa88b386dd3e9c6f2b6b81bb6e2bb7f9e6802d671bbf302d0b87141L8-R8) [[2]](diffhunk://#diff-5dac0ea71aa88b386dd3e9c6f2b6b81bb6e2bb7f9e6802d671bbf302d0b87141L49-R51) [[3]](diffhunk://#diff-5dac0ea71aa88b386dd3e9c6f2b6b81bb6e2bb7f9e6802d671bbf302d0b87141L73-R74)
* [`.github/workflows/sitl.yml`](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R57-R65): Renamed output `s3_path` to `bag_path` and updated the corresponding AWS S3 upload logic. [[1]](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R57-R65) [[2]](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602L96-R101) [[3]](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602L154-R160) [[4]](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602L190-R194)

### Timestamped Folder for Bag Files:

* [`.github/workflows/run.yml`](diffhunk://#diff-a3ddd7238fc6e36daeb0ef76e93fe15cc87824bd3299888075210c5ca6a474d3R63-R75): Added a new `set-timestamp` job to generate a timestamped folder name for organizing bag files. This folder name is passed as an output (`parent_folder`) to downstream jobs. [[1]](diffhunk://#diff-a3ddd7238fc6e36daeb0ef76e93fe15cc87824bd3299888075210c5ca6a474d3R63-R75) [[2]](diffhunk://#diff-a3ddd7238fc6e36daeb0ef76e93fe15cc87824bd3299888075210c5ca6a474d3R90)
* [`.github/workflows/sitl.yml`](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R57-R65): Introduced a new `parent_folder` input with a default value and updated the S3 folder structure to include the timestamped folder. [[1]](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602R57-R65) [[2]](diffhunk://#diff-1816183dcab3c992afc652301c256a06dd773ebaae4771ca6c4d000a9d8e1602L154-R160)

These changes enhance clarity in naming conventions and improve the organization of bag files by introducing a timestamped folder structure.