### PR TITLE
fix(data.yml): typo in single bag download

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -48,7 +48,7 @@ jobs:
             aws s3 cp "${{ inputs.bag_path }}" ./data --recursive
             echo "Downloaded all bag files from S3, folder: ${{ inputs.bag_path }}"
           else
-            aws s3 cp "${{ inputs.bag_path }}${{ inputs.bag_file_name }}" ./data/${{ inputs.bag_file_name }} --recursive
+            aws s3 cp "${{ inputs.bag_path }}/${{ inputs.bag_file_name }}" ./data/${{ inputs.bag_file_name }} --recursive
             echo "Downloaded single bag file from S3, file: ${{ inputs.bag_file_name }}"
           fi
         env:


### PR DESCRIPTION
This pull request fixes a minor issue in the `.github/workflows/data.yml` file, specifically addressing a path concatenation bug in the S3 file download logic.

Workflow improvement:

* [`.github/workflows/data.yml`](diffhunk://#diff-5dac0ea71aa88b386dd3e9c6f2b6b81bb6e2bb7f9e6802d671bbf302d0b87141L51-R51): Corrected the S3 path concatenation by adding a missing slash (`/`) between `inputs.bag_path` and `inputs.bag_file_name` to ensure proper file download behavior.