### PR TITLE
fix(sitl.yml): remove current time parent dir path

### DIFF
--- a/.github/workflows/sitl.yml
+++ b/.github/workflows/sitl.yml
@@ -155,7 +155,7 @@ jobs:
             sudo ./aws/install
             current_time=$(date +"%Y-%m-%d_%H-%M-%S")
             mv ~/bags/topic_report.md ~/bags/topic_report_${current_time}.md
-            export S3_FOLDER=${{ inputs.parent_folder }}/$current_time/
+            export S3_FOLDER=${{ inputs.parent_folder }}/
             aws s3 cp ~/bags "s3://$S3_FOLDER" --recursive
             echo "bag_path=s3://${{ inputs.parent_folder }}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/sitl.yml` file. The change simplifies the S3 folder structure by removing the timestamp from the `S3_FOLDER` path.