### PR TITLE
fix(data.yml): fix data path in multi bag scenario

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ inputs.multi_run == true }}
         run: |
           folder_name=$(basename "${{ inputs.bag_path }}")
-          python3 ./scripts/report_multi.py ./data/$folder_name --commit_id ${{ github.sha }} --author ${{ github.actor }}
+          python3 ./scripts/report_multi.py ./data/ --commit_id ${{ github.sha }} --author ${{ github.actor }}
           echo "Analysis complete."
 
       - name: Upload to Artifact


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/data.yml` file. The change modifies the `report_multi.py` script call to use the `./data/` directory directly instead of appending a folder name derived from the input bag path.