### PR TITLE
fix: radius as float

### DIFF
--- a/src/px4_ci_aws/launch/ci.launch.py
+++ b/src/px4_ci_aws/launch/ci.launch.py
@@ -173,7 +173,7 @@ def generate_launch_description():
             namespace='px4_offboard',
             executable='offboard_control',
             name='control',
-            parameters= [{'radius': radius},{'altitude': altitude},{'omega': omega}]
+            parameters= [{'radius': float(radius)},{'altitude': float(altitude)},{'omega': float(omega)}]
         )
     
     bag_path = f'/bags/{bag_name}'


### PR DESCRIPTION
This pull request includes a small but important change to the `generate_launch_description` function in `src/px4_ci_aws/launch/ci.launch.py`. The change ensures that the `radius`, `altitude`, and `omega` parameters are explicitly cast to `float` before being passed to the executable, improving type safety and preventing potential runtime errors.