### PR TITLE
fix(post-create.sh): force rosbags installation

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -40,6 +40,6 @@ sudo chmod 0700 /run/user/1000
 sudo mkdir /bags/
 sudo chown ros:ros /bags/
 
-echo "source /venv/bin/activate" >> ~/.bashrc
+pip install rosbags --break-system-packages
 
 echo "Done installing, ready to develop!"


### PR DESCRIPTION
This pull request updates the `.devcontainer/post_create.sh` script to improve the setup process for the development environment. The most significant change is the addition of the `rosbags` package installation.

Setup process updates:

* [`.devcontainer/post_create.sh`](diffhunk://#diff-79495a5ff44c04cd52db3561d48e92865b1b47e8738ddc27a489224de4914daaL43-R43): Replaced the addition of a virtual environment activation command to `~/.bashrc` with the installation of the `rosbags` package using `pip` and the `--break-system-packages` flag. This ensures the necessary package is available for development.